### PR TITLE
[MO-05] Edificios: Upgrade + Cola de construcción + Gran Salón

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1099,4 +1099,36 @@ Implementación completa del sistema de gestión de edificios para Midgard Onlin
 
 @qa revisar implementación antes de merge a `develop`. **PR no debe mergearse sin aprobación de @qa.**
 
+---
+
+## [QA] Review PR #20 — MO-05 Edificios
+
+**Fecha:** 2026-03-05
+**Agente:** @qa
+**PR:** #20 (`feature/MO-05-buildings` → `develop`)
+**Verdict:** ❌ BLOCKED
+
+### Resultado
+
+- `tsc --noEmit` backend + frontend: ✅ 0 errores
+- Acceptance criteria: 6/6 correctos en diseño
+- 5-Point QA Checklist: PASS (soft-lock, inflation, time walls, cross-resource, FTUE)
+
+### Issues
+
+- **B-002 (BLOQUEANTE):** `createVillageInTx` no crea filas de buildings → `startUpgrade` falla con `"Building 'X' not found in village"` para toda aldea nueva. El sistema de edificios es 100% inutilizable sin building seed.
+- **W-010:** `validateUpgrade` throws `"Forbidden: you do not own..."` pero route compara `=== "Forbidden"` → devuelve 500 en lugar de 403.
+- **W-011:** BuildingCard muestra tiempo base, sin reducción Gran Salón.
+- **W-012:** BuildingPanel stats comparison muestra label en vez de valor del siguiente nivel.
+- **W-013:** Progress bar desalineada con Gran Salón activo (base time denominador).
+- **W-014:** TOCTOU — SET absoluto vs decrement atómico en startUpgrade/cancelUpgrade.
+
+Warnings pendientes de PRs anteriores: W-004, W-005, W-006, W-007, W-008, W-009.
+
+### Acción
+
+@developer corregir B-002 (añadir building seed). @qa re-valida tras fix.
+
+Informe completo: `games/midgard-online/docs/qa-review-pr20-mo05-buildings.md`
+
 _Fin del registro actual. Añade nuevas entradas debajo._

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1131,4 +1131,20 @@ Warnings pendientes de PRs anteriores: W-004, W-005, W-006, W-007, W-008, W-009.
 
 Informe completo: `games/midgard-online/docs/qa-review-pr20-mo05-buildings.md`
 
+### [2026-03-05] - MO-05 QA Fixes: B-002 + W-010/W-011/W-012/W-013/W-014
+
+**Autor:** `@developer`
+**PR:** #20 — `feature/MO-05-buildings` → `develop`
+
+Corregidos todos los issues del QA Report `qa-review-pr20-mo05-buildings.md`.
+
+1. **B-002 (BLOQUEANTE) — Building seed en aldeas nuevas:** `createVillageInTx` crea 21 building rows a Lv.0 (woodcutter×4, claypit×4, ironMine×4, farm×6, mainBuilding, warehouse, granary). Sistema funcional para nuevos jugadores.
+2. **W-010 — 500 → 403:** `validateUpgrade` lanza `"Forbidden"` (igual que `cancelUpgrade`) → route handler matchea y devuelve 403.
+3. **W-011 — Tiempo efectivo:** `getVillageBuildings` retorna `effectiveBuildTimeSec` con reducción Gran Salón aplicada. `BuildingCard` muestra el tiempo real.
+4. **W-012 — Valor siguiente nivel:** `getVillageBuildings` retorna `nextLevelStats`. `BuildingPanel` usa su valor en lugar del label.
+5. **W-013 — Progress bar:** Denominador usa `effectiveBuildTimeSec` → barra empieza en 0% con Gran Salón activo.
+6. **W-014 — Atómico:** `startUpgrade` usa `{ decrement }`, `cancelUpgrade` usa `{ increment }` en Prisma.
+
+**Verificación:** `tsc --noEmit` backend ✅ + frontend ✅ — 0 errores.
+
 _Fin del registro actual. Añade nuevas entradas debajo._

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1147,4 +1147,25 @@ Corregidos todos los issues del QA Report `qa-review-pr20-mo05-buildings.md`.
 
 **Verificación:** `tsc --noEmit` backend ✅ + frontend ✅ — 0 errores.
 
+### [2026-03-05] - QA Re-Review PR #20 — MO-05 Edificios ✅ APPROVED
+
+**Autor:** `@qa`
+**PR:** #20 — `feature/MO-05-buildings` → `develop`
+
+Re-revisión tras commit `3b67a5b` con fixes de @developer.
+
+**Verificación:**
+
+- **B-002** (BLOQUEANTE): `createVillageInTx` crea 21 building rows a Lv0 — ✅ RESUELTO
+- **W-010**: Error message → `"Forbidden"` matchea 403 — ✅ RESUELTO
+- **W-011**: `effectiveBuildTimeSec` retornado y mostrado en BuildingCard — ✅ RESUELTO
+- **W-012**: `nextLevelStats` retornado y mostrado en BuildingPanel — ✅ RESUELTO
+- **W-013**: Progress bar usa `effectiveBuildTimeSec ?? nextLevelTimeSec` — ✅ RESUELTO
+- **W-014**: Prisma `decrement`/`increment` atómicos — ✅ RESUELTO
+- `tsc --noEmit` backend + frontend: 0 errores
+
+**Resultado:** ✅ QA APPROVED — todos los issues resueltos. Listo para merge.
+
+Informe actualizado: `games/midgard-online/docs/qa-review-pr20-mo05-buildings.md`
+
 _Fin del registro actual. Añade nuevas entradas debajo._

--- a/games/midgard-online/backend/src/cron/buildingChecker.ts
+++ b/games/midgard-online/backend/src/cron/buildingChecker.ts
@@ -1,0 +1,63 @@
+/**
+ * BuildingChecker — runs every MISSION_CHECK_INTERVAL_MS (default 5 s).
+ *
+ * Checks all buildings with upgradeFinishAt ≤ now.
+ * For each:
+ *   1. Increment level
+ *   2. Clear upgradeFinishAt
+ *   3. Update village population
+ *   4. Emit Socket.io event `building:complete` to room `village:<villageId>`
+ */
+
+import { prisma } from "../config/database.js";
+import { env } from "../config/env.js";
+import { completeUpgrade } from "../services/buildingService.js";
+import { getIO } from "../ws/socketServer.js";
+
+export function startBuildingChecker(): void {
+  console.log(
+    `[CRON] Building checker started (every ${env.MISSION_CHECK_INTERVAL_MS / 1000}s)`,
+  );
+
+  setInterval(() => {
+    runBuildingChecker().catch((err: unknown) => {
+      console.error("[CRON] Building checker error:", err);
+    });
+  }, env.MISSION_CHECK_INTERVAL_MS);
+}
+
+async function runBuildingChecker(): Promise<void> {
+  const now = new Date();
+
+  // Find all buildings whose upgrade timer has elapsed
+  const due = await prisma.building.findMany({
+    where: {
+      upgradeFinishAt: { lte: now },
+    },
+    select: { id: true },
+  });
+
+  if (due.length === 0) return;
+
+  for (const { id } of due) {
+    try {
+      const result = await completeUpgrade(id);
+
+      // Emit to village room
+      try {
+        getIO().to(`village:${result.villageId}`).emit("building:complete", {
+          buildingType: result.building.buildingType,
+          newLevel: result.building.newLevel,
+        });
+      } catch {
+        // IO not ready — safe
+      }
+
+      console.log(
+        `[CRON] Building complete: ${result.building.buildingType} → Lv${result.building.newLevel} (village ${result.villageId})`,
+      );
+    } catch (err) {
+      console.error(`[CRON] Failed to complete building ${id}:`, err);
+    }
+  }
+}

--- a/games/midgard-online/backend/src/index.ts
+++ b/games/midgard-online/backend/src/index.ts
@@ -10,6 +10,7 @@ import { createServer } from "http";
 import { env } from "./config/env.js";
 import { setupSocketServer } from "./ws/socketServer.js";
 import { startProductionTick } from "./cron/productionTick.js";
+import { startBuildingChecker } from "./cron/buildingChecker.js";
 import { authRouter } from "./routes/auth.js";
 import { villagesRouter } from "./routes/villages.js";
 import { buildingsRouter } from "./routes/buildings.js";
@@ -52,6 +53,7 @@ httpServer.listen(env.PORT, () => {
   console.log(`⚔️  Midgard Online API running on http://localhost:${env.PORT}`);
   console.log(`   Environment: ${env.NODE_ENV}`);
   startProductionTick();
+  startBuildingChecker();
 });
 
 // ── Global error handler (W-001: catches unhandled async errors in Express 4) ──

--- a/games/midgard-online/backend/src/routes/buildings.ts
+++ b/games/midgard-online/backend/src/routes/buildings.ts
@@ -1,15 +1,96 @@
-import { Router } from 'express';
+import {
+  Router,
+  type NextFunction,
+  type Request,
+  type Response,
+} from "express";
+import { z } from "zod";
+import { authMiddleware, type AuthRequest } from "../middleware/auth.js";
+import { startUpgrade, cancelUpgrade } from "../services/buildingService.js";
 
 export const buildingsRouter = Router();
 
-// POST /buildings/upgrade
-buildingsRouter.post('/upgrade', (_req, res) => {
-  // TODO: validate resources, start upgrade timer
-  res.status(501).json({ error: 'Not implemented' });
+// ── POST /buildings/upgrade ───────────────────────────────────
+// Start a building upgrade. Deducts resources and sets timer.
+
+const upgradeBodySchema = z.object({
+  villageId: z.string().uuid(),
+  buildingType: z.string().min(1).max(30),
 });
 
-// DELETE /buildings/upgrade/:id
-buildingsRouter.delete('/upgrade/:id', (_req, res) => {
-  // TODO: cancel active construction
-  res.status(501).json({ error: 'Not implemented' });
-});
+buildingsRouter.post(
+  "/upgrade",
+  authMiddleware,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const parsed = upgradeBodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        res
+          .status(400)
+          .json({ error: "Invalid request", details: parsed.error.errors });
+        return;
+      }
+
+      const { userId } = (req as AuthRequest).user;
+      const { villageId, buildingType } = parsed.data;
+
+      const result = await startUpgrade(villageId, buildingType, userId);
+      res.status(201).json(result);
+    } catch (err) {
+      if (
+        err instanceof Error &&
+        (err.message.startsWith("Insufficient") ||
+          err.message.startsWith("Requires") ||
+          err.message.startsWith("Another building") ||
+          err.message.startsWith("Building '") ||
+          err.message.startsWith("Unknown building"))
+      ) {
+        res.status(422).json({ error: err.message });
+        return;
+      }
+      if (err instanceof Error && err.message === "Forbidden") {
+        res.status(403).json({ error: "Forbidden" });
+        return;
+      }
+      if (err instanceof Error && err.message === "Village not found") {
+        res.status(404).json({ error: "Village not found" });
+        return;
+      }
+      next(err);
+    }
+  },
+);
+
+// ── DELETE /buildings/upgrade/:id ────────────────────────────
+// Cancel an active construction. Refunds 100% of resources.
+
+buildingsRouter.delete(
+  "/upgrade/:id",
+  authMiddleware,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const buildingId = req.params["id"] as string;
+      const { userId } = (req as AuthRequest).user;
+
+      const result = await cancelUpgrade(buildingId, userId);
+      res.json(result);
+    } catch (err) {
+      if (err instanceof Error && err.message === "Building not found") {
+        res.status(404).json({ error: "Building not found" });
+        return;
+      }
+      if (
+        err instanceof Error &&
+        err.message === "Building is not currently upgrading"
+      ) {
+        res.status(422).json({ error: err.message });
+        return;
+      }
+      if (err instanceof Error && err.message === "Forbidden") {
+        res.status(403).json({ error: "Forbidden" });
+        return;
+      }
+      next(err);
+    }
+  },
+);

--- a/games/midgard-online/backend/src/services/buildingService.ts
+++ b/games/midgard-online/backend/src/services/buildingService.ts
@@ -3,11 +3,429 @@
  *
  * Responsibilities:
  * - Check resource availability against BuildingsConfig levels
- * - Verify prerequisites (e.g. mainBuilding level)
- * - Apply construction speed modifiers from mainBuilding
- * - Deduct resources and set upgrade_finish_at
+ * - Verify prerequisites (mainBuilding unlocks table)
+ * - Apply construction speed modifiers from mainBuilding (-3%/level, max -30%)
+ * - Deduct resources and set upgradeFinishAt
+ * - Refund 100% resources on cancel
+ * - Increment level and update population on complete
  */
 
-export class BuildingService {
-  // TODO: implement upgrade validation + execution
+import type { Prisma } from "@prisma/client";
+import { prisma } from "../config/database.js";
+import { gameData } from "../config/gameData.js";
+
+// ── Config types ──────────────────────────────────────────────
+
+interface BuildingLevelConfig {
+  level: number;
+  costs: { wood: number; clay: number; iron: number; wheat: number };
+  timeSec: number;
+  productionPerHour?: number;
+  capacityPerResource?: number;
+  capacityWheat?: number;
+  buildTimeReduction?: number;
+  population: number;
+}
+
+interface BuildingCfg {
+  id: string;
+  name: string;
+  maxLevel: number;
+  maxPerVillage: number;
+  levels: BuildingLevelConfig[];
+}
+
+interface MainBuildingCfg extends BuildingCfg {
+  unlocks: Record<string, string[]>;
+}
+
+interface BuildingsCfgRoot {
+  buildings: Record<string, BuildingCfg>;
+}
+
+const buildingsCfg = gameData.buildings as unknown as BuildingsCfgRoot;
+
+// ── Output types ──────────────────────────────────────────────
+
+export interface ResourceValues {
+  wood: number;
+  clay: number;
+  iron: number;
+  wheat: number;
+}
+
+export interface BuildingWithStats {
+  id: string;
+  buildingType: string;
+  slotIndex: number;
+  level: number;
+  upgradeFinishAt: Date | null;
+  name: string;
+  maxLevel: number;
+  currentStats: BuildingLevelConfig | null;
+  nextLevelCost: ResourceValues | null;
+  nextLevelTimeSec: number | null;
+}
+
+export interface UpgradeResult {
+  building: {
+    id: string;
+    buildingType: string;
+    level: number;
+    upgradeFinishAt: Date | null;
+  };
+  resourcesAfter: ResourceValues;
+}
+
+// ── Config helpers ────────────────────────────────────────────
+
+export function getBuildingConfig(buildingType: string): BuildingCfg | null {
+  return buildingsCfg.buildings[buildingType] ?? null;
+}
+
+/**
+ * Returns the upgrade cost for a building at the given TARGET level.
+ * Levels in config are 1-indexed; targetLevel = currentLevel + 1.
+ */
+export function getUpgradeCost(
+  buildingType: string,
+  targetLevel: number,
+): ResourceValues | null {
+  const cfg = buildingsCfg.buildings[buildingType];
+  if (!cfg) return null;
+  const levelCfg = cfg.levels[targetLevel - 1];
+  if (!levelCfg) return null;
+  return {
+    wood: levelCfg.costs.wood,
+    clay: levelCfg.costs.clay,
+    iron: levelCfg.costs.iron,
+    wheat: levelCfg.costs.wheat,
+  };
+}
+
+/**
+ * Returns effective build time in seconds, applying mainBuilding time reduction.
+ * Formula: baseTime × (1 - mainBuildingLevel × 0.03), min 10s
+ */
+export function getBuildTime(
+  buildingType: string,
+  targetLevel: number,
+  mainBuildingLevel: number,
+): number {
+  const cfg = buildingsCfg.buildings[buildingType];
+  if (!cfg) return 60;
+  const levelCfg = cfg.levels[targetLevel - 1];
+  if (!levelCfg) return 60;
+  const reduction = Math.min(mainBuildingLevel * 0.03, 0.3); // cap at 30%
+  return Math.max(10, Math.round(levelCfg.timeSec * (1 - reduction)));
+}
+
+/**
+ * Returns the minimum mainBuilding level required to build this buildingType.
+ * Reads from mainBuilding.unlocks in BuildingsConfig.
+ */
+function getRequiredMainBuildingLevel(buildingType: string): number {
+  const mainCfg = buildingsCfg.buildings["mainBuilding"] as MainBuildingCfg;
+  if (!mainCfg?.unlocks) return 1;
+  for (const [lvlStr, types] of Object.entries(mainCfg.unlocks)) {
+    if ((types as string[]).includes(buildingType)) {
+      return parseInt(lvlStr, 10);
+    }
+  }
+  return 0; // not in unlocks table — always available
+}
+
+// ── Core service functions ────────────────────────────────────
+
+/**
+ * Returns all buildings for a village, enriched with config stats.
+ */
+export async function getVillageBuildings(
+  villageId: string,
+): Promise<BuildingWithStats[]> {
+  const buildings = await prisma.building.findMany({
+    where: { villageId },
+    orderBy: [{ slotIndex: "asc" }],
+  });
+
+  return buildings.map((b) => {
+    const cfg = buildingsCfg.buildings[b.buildingType];
+    const currentStats = cfg?.levels[b.level - 1] ?? null;
+    const nextLevelCost =
+      b.level < (cfg?.maxLevel ?? 10)
+        ? getUpgradeCost(b.buildingType, b.level + 1)
+        : null;
+    const nextLevelTimeSec =
+      b.level < (cfg?.maxLevel ?? 10)
+        ? (cfg?.levels[b.level]?.timeSec ?? null)
+        : null;
+
+    return {
+      id: b.id,
+      buildingType: b.buildingType,
+      slotIndex: b.slotIndex,
+      level: b.level,
+      upgradeFinishAt: b.upgradeFinishAt,
+      name: cfg?.name ?? b.buildingType,
+      maxLevel: cfg?.maxLevel ?? 10,
+      currentStats,
+      nextLevelCost,
+      nextLevelTimeSec,
+    };
+  });
+}
+
+/**
+ * Validates all preconditions for upgrading a building.
+ * Throws with descriptive error message if any check fails.
+ * Returns the building row and current resource snapshot on success.
+ */
+async function validateUpgrade(
+  villageId: string,
+  buildingType: string,
+  userId: string,
+) {
+  // 1. Verify village ownership
+  const village = await prisma.village.findUnique({
+    where: { id: villageId },
+    include: {
+      resources: true,
+      buildings: {
+        where: { buildingType: "mainBuilding" },
+        select: { level: true },
+      },
+    },
+  });
+
+  if (!village) throw new Error("Village not found");
+  if (village.ownerId !== userId)
+    throw new Error("Forbidden: you do not own this village");
+  if (!village.resources) throw new Error("Village has no resource record");
+
+  // 2. Find the building
+  const building = await prisma.building.findFirst({
+    where: { villageId, buildingType },
+  });
+  if (!building)
+    throw new Error(`Building '${buildingType}' not found in village`);
+
+  // 3. Check max level
+  const cfg = buildingsCfg.buildings[buildingType];
+  if (!cfg) throw new Error(`Unknown building type: ${buildingType}`);
+  const targetLevel = building.level + 1;
+  if (targetLevel > cfg.maxLevel)
+    throw new Error(
+      `Building '${buildingType}' is already at max level ${cfg.maxLevel}`,
+    );
+
+  // 4. Check no other building currently upgrading (v0.1.0: 1 concurrent)
+  const inProgress = await prisma.building.findFirst({
+    where: { villageId, upgradeFinishAt: { not: null } },
+  });
+  if (inProgress) {
+    throw new Error(
+      `Another building (${inProgress.buildingType}) is already under construction`,
+    );
+  }
+
+  // 5. Check mainBuilding prerequisite
+  const mainBuildingLevel = village.buildings[0]?.level ?? 0;
+  const requiredMainLevel = getRequiredMainBuildingLevel(buildingType);
+  if (mainBuildingLevel < requiredMainLevel) {
+    throw new Error(
+      `Requires Gran Salón level ${requiredMainLevel} (current: ${mainBuildingLevel})`,
+    );
+  }
+
+  // 6. Check sufficient resources
+  const cost = getUpgradeCost(buildingType, targetLevel);
+  if (!cost) throw new Error("Could not determine upgrade cost");
+
+  const res = village.resources;
+  const wood = Number(res.wood);
+  const clay = Number(res.clay);
+  const iron = Number(res.iron);
+  const wheat = Number(res.wheat);
+
+  if (
+    wood < cost.wood ||
+    clay < cost.clay ||
+    iron < cost.iron ||
+    wheat < cost.wheat
+  ) {
+    throw new Error(
+      `Insufficient resources. Need: ${cost.wood}w/${cost.clay}c/${cost.iron}i/${cost.wheat}f`,
+    );
+  }
+
+  return {
+    village,
+    building,
+    resources: { wood, clay, iron, wheat },
+    cost,
+    mainBuildingLevel,
+  };
+}
+
+/**
+ * Starts an upgrade: deducts resources and sets upgradeFinishAt.
+ * Returns the updated building and resources.
+ */
+export async function startUpgrade(
+  villageId: string,
+  buildingType: string,
+  userId: string,
+): Promise<UpgradeResult> {
+  const { village, building, resources, cost, mainBuildingLevel } =
+    await validateUpgrade(villageId, buildingType, userId);
+
+  const targetLevel = building.level + 1;
+  const buildTimeSec = getBuildTime(
+    buildingType,
+    targetLevel,
+    mainBuildingLevel,
+  );
+  const upgradeFinishAt = new Date(Date.now() + buildTimeSec * 1000);
+
+  const updatedResource: Prisma.ResourceUpdateInput = {
+    wood: resources.wood - cost.wood,
+    clay: resources.clay - cost.clay,
+    iron: resources.iron - cost.iron,
+    wheat: resources.wheat - cost.wheat,
+    lastUpdated: new Date(),
+  };
+
+  const [updatedBuilding, updatedRes] = await prisma.$transaction([
+    prisma.building.update({
+      where: { id: building.id },
+      data: { upgradeFinishAt },
+    }),
+    prisma.resource.update({
+      where: { villageId: village.id },
+      data: updatedResource,
+    }),
+  ]);
+
+  return {
+    building: {
+      id: updatedBuilding.id,
+      buildingType: updatedBuilding.buildingType,
+      level: updatedBuilding.level,
+      upgradeFinishAt: updatedBuilding.upgradeFinishAt,
+    },
+    resourcesAfter: {
+      wood: Number(updatedRes.wood),
+      clay: Number(updatedRes.clay),
+      iron: Number(updatedRes.iron),
+      wheat: Number(updatedRes.wheat),
+    },
+  };
+}
+
+/**
+ * Cancels an active upgrade, refunding 100% of resources.
+ */
+export async function cancelUpgrade(
+  buildingId: string,
+  userId: string,
+): Promise<UpgradeResult> {
+  const building = await prisma.building.findUnique({
+    where: { id: buildingId },
+    include: {
+      village: { include: { resources: true } },
+    },
+  });
+
+  if (!building) throw new Error("Building not found");
+  if (!building.upgradeFinishAt)
+    throw new Error("Building is not currently upgrading");
+  if (building.village.ownerId !== userId) throw new Error("Forbidden");
+  if (!building.village.resources)
+    throw new Error("Village has no resource record");
+
+  // 100% refund of target level cost
+  const targetLevel = building.level + 1;
+  const refund = getUpgradeCost(building.buildingType, targetLevel);
+  if (!refund) throw new Error("Could not determine refund cost");
+
+  const res = building.village.resources;
+  const [updatedBuilding, updatedRes] = await prisma.$transaction([
+    prisma.building.update({
+      where: { id: building.id },
+      data: { upgradeFinishAt: null },
+    }),
+    prisma.resource.update({
+      where: { villageId: building.villageId },
+      data: {
+        wood: Number(res.wood) + refund.wood,
+        clay: Number(res.clay) + refund.clay,
+        iron: Number(res.iron) + refund.iron,
+        wheat: Number(res.wheat) + refund.wheat,
+        lastUpdated: new Date(),
+      },
+    }),
+  ]);
+
+  return {
+    building: {
+      id: updatedBuilding.id,
+      buildingType: updatedBuilding.buildingType,
+      level: updatedBuilding.level,
+      upgradeFinishAt: updatedBuilding.upgradeFinishAt,
+    },
+    resourcesAfter: {
+      wood: Number(updatedRes.wood),
+      clay: Number(updatedRes.clay),
+      iron: Number(updatedRes.iron),
+      wheat: Number(updatedRes.wheat),
+    },
+  };
+}
+
+/**
+ * Completes a build: increments level, clears timer, updates village population.
+ * Returns the updated building and the villageId for WS emit.
+ */
+export async function completeUpgrade(
+  buildingId: string,
+): Promise<{
+  building: { id: string; buildingType: string; newLevel: number };
+  villageId: string;
+}> {
+  const building = await prisma.building.findUnique({
+    where: { id: buildingId },
+  });
+
+  if (!building) throw new Error("Building not found");
+  if (!building.upgradeFinishAt) throw new Error("Building is not upgrading");
+
+  const oldLevel = building.level;
+  const newLevel = oldLevel + 1;
+  const cfg = buildingsCfg.buildings[building.buildingType];
+
+  // Population delta: newLevelConfig.population - prevLevelConfig.population
+  const newLevelPop = cfg?.levels[newLevel - 1]?.population ?? 0;
+  const oldLevelPop =
+    oldLevel > 0 ? (cfg?.levels[oldLevel - 1]?.population ?? 0) : 0;
+  const populationDelta = newLevelPop - oldLevelPop;
+
+  const [updatedBuilding] = await prisma.$transaction([
+    prisma.building.update({
+      where: { id: building.id },
+      data: { level: newLevel, upgradeFinishAt: null },
+    }),
+    prisma.village.update({
+      where: { id: building.villageId },
+      data: { population: { increment: populationDelta } },
+    }),
+  ]);
+
+  return {
+    building: {
+      id: updatedBuilding.id,
+      buildingType: updatedBuilding.buildingType,
+      newLevel,
+    },
+    villageId: building.villageId,
+  };
 }

--- a/games/midgard-online/backend/src/services/buildingService.ts
+++ b/games/midgard-online/backend/src/services/buildingService.ts
@@ -10,7 +10,6 @@
  * - Increment level and update population on complete
  */
 
-import type { Prisma } from "@prisma/client";
 import { prisma } from "../config/database.js";
 import { gameData } from "../config/gameData.js";
 
@@ -63,8 +62,10 @@ export interface BuildingWithStats {
   name: string;
   maxLevel: number;
   currentStats: BuildingLevelConfig | null;
+  nextLevelStats: BuildingLevelConfig | null;
   nextLevelCost: ResourceValues | null;
   nextLevelTimeSec: number | null;
+  effectiveBuildTimeSec: number | null;
 }
 
 export interface UpgradeResult {
@@ -148,17 +149,26 @@ export async function getVillageBuildings(
     orderBy: [{ slotIndex: "asc" }],
   });
 
+  // W-011/W-013: need mainBuilding level to compute effective build times
+  const mainBuildingLevel =
+    buildings.find((b) => b.buildingType === "mainBuilding")?.level ?? 0;
+
   return buildings.map((b) => {
     const cfg = buildingsCfg.buildings[b.buildingType];
+    const hasNextLevel = b.level < (cfg?.maxLevel ?? 10);
     const currentStats = cfg?.levels[b.level - 1] ?? null;
-    const nextLevelCost =
-      b.level < (cfg?.maxLevel ?? 10)
-        ? getUpgradeCost(b.buildingType, b.level + 1)
-        : null;
-    const nextLevelTimeSec =
-      b.level < (cfg?.maxLevel ?? 10)
-        ? (cfg?.levels[b.level]?.timeSec ?? null)
-        : null;
+    // W-012: next level stats (index = b.level because levels array is 0-indexed)
+    const nextLevelStats = hasNextLevel ? (cfg?.levels[b.level] ?? null) : null;
+    const nextLevelCost = hasNextLevel
+      ? getUpgradeCost(b.buildingType, b.level + 1)
+      : null;
+    const nextLevelTimeSec = hasNextLevel
+      ? (cfg?.levels[b.level]?.timeSec ?? null)
+      : null;
+    // W-011/W-013: effective time with Gran Salón reduction applied
+    const effectiveBuildTimeSec = hasNextLevel
+      ? getBuildTime(b.buildingType, b.level + 1, mainBuildingLevel)
+      : null;
 
     return {
       id: b.id,
@@ -169,8 +179,10 @@ export async function getVillageBuildings(
       name: cfg?.name ?? b.buildingType,
       maxLevel: cfg?.maxLevel ?? 10,
       currentStats,
+      nextLevelStats,
       nextLevelCost,
       nextLevelTimeSec,
+      effectiveBuildTimeSec,
     };
   });
 }
@@ -198,8 +210,7 @@ async function validateUpgrade(
   });
 
   if (!village) throw new Error("Village not found");
-  if (village.ownerId !== userId)
-    throw new Error("Forbidden: you do not own this village");
+  if (village.ownerId !== userId) throw new Error("Forbidden"); // W-010: consistent with routes/buildings.ts error check
   if (!village.resources) throw new Error("Village has no resource record");
 
   // 2. Find the building
@@ -276,8 +287,11 @@ export async function startUpgrade(
   buildingType: string,
   userId: string,
 ): Promise<UpgradeResult> {
-  const { village, building, resources, cost, mainBuildingLevel } =
-    await validateUpgrade(villageId, buildingType, userId);
+  const { village, building, cost, mainBuildingLevel } = await validateUpgrade(
+    villageId,
+    buildingType,
+    userId,
+  );
 
   const targetLevel = building.level + 1;
   const buildTimeSec = getBuildTime(
@@ -287,14 +301,7 @@ export async function startUpgrade(
   );
   const upgradeFinishAt = new Date(Date.now() + buildTimeSec * 1000);
 
-  const updatedResource: Prisma.ResourceUpdateInput = {
-    wood: resources.wood - cost.wood,
-    clay: resources.clay - cost.clay,
-    iron: resources.iron - cost.iron,
-    wheat: resources.wheat - cost.wheat,
-    lastUpdated: new Date(),
-  };
-
+  // W-014: atomic decrements protect against TOCTOU race with productionTick
   const [updatedBuilding, updatedRes] = await prisma.$transaction([
     prisma.building.update({
       where: { id: building.id },
@@ -302,7 +309,13 @@ export async function startUpgrade(
     }),
     prisma.resource.update({
       where: { villageId: village.id },
-      data: updatedResource,
+      data: {
+        wood: { decrement: cost.wood },
+        clay: { decrement: cost.clay },
+        iron: { decrement: cost.iron },
+        wheat: { decrement: cost.wheat },
+        lastUpdated: new Date(),
+      },
     }),
   ]);
 
@@ -348,7 +361,7 @@ export async function cancelUpgrade(
   const refund = getUpgradeCost(building.buildingType, targetLevel);
   if (!refund) throw new Error("Could not determine refund cost");
 
-  const res = building.village.resources;
+  // W-014: atomic increments for 100% refund
   const [updatedBuilding, updatedRes] = await prisma.$transaction([
     prisma.building.update({
       where: { id: building.id },
@@ -357,10 +370,10 @@ export async function cancelUpgrade(
     prisma.resource.update({
       where: { villageId: building.villageId },
       data: {
-        wood: Number(res.wood) + refund.wood,
-        clay: Number(res.clay) + refund.clay,
-        iron: Number(res.iron) + refund.iron,
-        wheat: Number(res.wheat) + refund.wheat,
+        wood: { increment: refund.wood },
+        clay: { increment: refund.clay },
+        iron: { increment: refund.iron },
+        wheat: { increment: refund.wheat },
         lastUpdated: new Date(),
       },
     }),
@@ -386,9 +399,7 @@ export async function cancelUpgrade(
  * Completes a build: increments level, clears timer, updates village population.
  * Returns the updated building and the villageId for WS emit.
  */
-export async function completeUpgrade(
-  buildingId: string,
-): Promise<{
+export async function completeUpgrade(buildingId: string): Promise<{
   building: { id: string; buildingType: string; newLevel: number };
   villageId: string;
 }> {

--- a/games/midgard-online/backend/src/services/villageService.ts
+++ b/games/midgard-online/backend/src/services/villageService.ts
@@ -127,6 +127,56 @@ export async function createVillageInTx(
     },
   });
 
+  // B-002: seed all Phase-1 building slots at level 0 so startUpgrade can find them
+  await tx.building.createMany({
+    data: [
+      // Resource fields: 4 woodcutter, 4 claypit, 4 ironMine, 6 farm
+      ...Array.from({ length: 4 }, (_, i) => ({
+        villageId: village.id,
+        buildingType: "woodcutter",
+        slotIndex: i,
+        level: 0,
+      })),
+      ...Array.from({ length: 4 }, (_, i) => ({
+        villageId: village.id,
+        buildingType: "claypit",
+        slotIndex: 4 + i,
+        level: 0,
+      })),
+      ...Array.from({ length: 4 }, (_, i) => ({
+        villageId: village.id,
+        buildingType: "ironMine",
+        slotIndex: 8 + i,
+        level: 0,
+      })),
+      ...Array.from({ length: 6 }, (_, i) => ({
+        villageId: village.id,
+        buildingType: "farm",
+        slotIndex: 12 + i,
+        level: 0,
+      })),
+      // Inner buildings (Phase 1)
+      {
+        villageId: village.id,
+        buildingType: "mainBuilding",
+        slotIndex: 18,
+        level: 0,
+      },
+      {
+        villageId: village.id,
+        buildingType: "warehouse",
+        slotIndex: 19,
+        level: 0,
+      },
+      {
+        villageId: village.id,
+        buildingType: "granary",
+        slotIndex: 20,
+        level: 0,
+      },
+    ],
+  });
+
   return village.id;
 }
 

--- a/games/midgard-online/docs/qa-review-pr20-mo05-buildings.md
+++ b/games/midgard-online/docs/qa-review-pr20-mo05-buildings.md
@@ -1,0 +1,354 @@
+# 🔍 QA Report: PR #20 — [MO-05] Edificios: Upgrade + Cola de construcción + Gran Salón
+
+**PR:** https://github.com/afernandezro7/ai-game-studio/pull/20
+**Rama:** `feature/MO-05-buildings` → `develop`
+**Issue:** #11
+**Fecha:** 2026-03-05
+**Verdict:** ❌ BLOCKED — 1 bloqueante (B-002)
+
+---
+
+## TypeScript Compilation
+
+| Proyecto                                      | Resultado                     |
+| --------------------------------------------- | ----------------------------- |
+| Backend (`games/midgard-online/backend`)      | ✅ `tsc --noEmit` — 0 errores |
+| Frontend (`games/midgard-online/sandbox-web`) | ✅ `tsc --noEmit` — 0 errores |
+
+---
+
+## Acceptance Criteria vs Implementation
+
+| #   | Criterio                                                                       | Estado | Notas                                                                                        |
+| --- | ------------------------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------------------- |
+| 1   | Mejorar un edificio descuenta los recursos correctos de `BuildingsConfig.json` | ✅     | `getUpgradeCost` lee `cfg.levels[targetLevel-1].costs` — correcto                            |
+| 2   | El timer de construcción es exacto al segundo                                  | ✅     | `upgradeFinishAt = Date.now() + buildTimeSec*1000`; countdown frontend usa `setInterval(1s)` |
+| 3   | El Gran Salón reduce tiempos en -3%/nivel (máx -30% en Lv10)                   | ✅     | `getBuildTime`: `reduction = Math.min(mbLv*0.03, 0.3)` — correcto                            |
+| 4   | No se puede mejorar si los recursos son insuficientes                          | ✅     | `validateUpgrade` compara los 4 recursos → throw `"Insufficient resources"`                  |
+| 5   | Al completarse la mejora, la producción/capacidad sube instantáneamente        | ✅     | `completeUpgrade` incrementa nivel + emit `building:complete` → front invalida queries       |
+| 6   | Cola de construcción: solo 1 edificio en construcción a la vez en v0.1.0       | ✅     | `findFirst where { villageId, upgradeFinishAt: not null }` → throw si existe                 |
+
+---
+
+## Issues Found
+
+### ❌ B-002 (BLOQUEANTE): `startUpgrade` falla para aldeas nuevas — no existen filas de edificios
+
+**Ubicación:** `buildingService.ts` → `validateUpgrade()` (línea ~219) + `villageService.ts` → `createVillageInTx()` (línea ~84)
+
+**Descripción:**
+`validateUpgrade` busca una fila existente en la tabla `buildings`:
+
+```ts
+const building = await prisma.building.findFirst({
+  where: { villageId, buildingType },
+});
+if (!building)
+  throw new Error(`Building '${buildingType}' not found in village`);
+```
+
+Pero `createVillageInTx` (registro de usuario) crea la aldea con resources + mapCell pero **NO crea ninguna fila de building**. Un jugador recién registrado recibirá:
+
+```
+422 — "Building 'mainBuilding' not found in village"
+```
+
+para CUALQUIER intento de mejora.
+
+**Impacto:** Sistema de edificios 100% inutilizable para aldeas nuevas. Bloquea el flujo completo de MO-05.
+
+**Fix propuesto:** Añadir seed de buildings en `createVillageInTx` al crear la aldea. Crear las 38 filas (18 resource slots + 20 inner slots) a nivel 0:
+
+```ts
+// En createVillageInTx, después de crear resource y mapCell:
+const buildingSeeds = [
+  // Resource slots (18): 4 wood, 4 clay, 4 iron, 6 wheat
+  ...Array.from({ length: 4 }, (_, i) => ({
+    buildingType: "woodcutter",
+    slotIndex: i,
+  })),
+  ...Array.from({ length: 4 }, (_, i) => ({
+    buildingType: "claypit",
+    slotIndex: 4 + i,
+  })),
+  ...Array.from({ length: 4 }, (_, i) => ({
+    buildingType: "ironMine",
+    slotIndex: 8 + i,
+  })),
+  ...Array.from({ length: 6 }, (_, i) => ({
+    buildingType: "farm",
+    slotIndex: 12 + i,
+  })),
+  // Inner buildings (phase 1)
+  { buildingType: "mainBuilding", slotIndex: 18 },
+  { buildingType: "warehouse", slotIndex: 19 },
+  { buildingType: "granary", slotIndex: 20 },
+];
+await tx.building.createMany({
+  data: buildingSeeds.map((s) => ({
+    villageId: village.id,
+    buildingType: s.buildingType,
+    slotIndex: s.slotIndex,
+    level: 0,
+  })),
+});
+```
+
+---
+
+### ⚠️ W-010: `startUpgrade` ownership → 500 en lugar de 403
+
+**Ubicación:** `buildingService.ts:202` vs `routes/buildings.ts:45`
+
+**Descripción:**
+`validateUpgrade` lanza `throw new Error("Forbidden: you do not own this village")` pero la ruta compara exacto con `err.message === "Forbidden"`. El check NO matchea → cae al `next(err)` → **500 Internal Server Error** en lugar de **403 Forbidden**.
+
+`cancelUpgrade` SÍ lanza `"Forbidden"` (matchea correctamente).
+
+**Fix:** Cambiar `validateUpgrade` línea 202: `throw new Error("Forbidden")` (consistente con cancelUpgrade).
+
+---
+
+### ⚠️ W-011: BuildingCard muestra tiempo base, no efectivo (sin reducción Gran Salón)
+
+**Ubicación:** `BuildingCard.tsx:196-199`
+
+**Descripción:**
+El coste de tiempo en la tarjeta usa `building.nextLevelTimeSec` directamente, que es el tiempo BASE del config (sin reducción del Gran Salón). El backend retorna `cfg.levels[b.level]?.timeSec`, que NO aplica la reducción.
+
+`BuildingPanel.tsx` SÍ calcula `effectiveTime(base, mainBuildingLevel)` — pero `BuildingCard` no recibe `mainBuildingLevel` y muestra el tiempo base.
+
+Ejemplo: Woodcutter Lv2 con Gran Salón Lv5 → Base: 279s, Efectivo: 237s. La tarjeta mostraría "4m 39s" en lugar de "3m 57s".
+
+**Fix:** Pasar `mainBuildingLevel` a BuildingCard, o retornar `effectiveBuildTimeSec` desde el backend en `getVillageBuildings`.
+
+---
+
+### ⚠️ W-012: BuildingPanel muestra label en lugar del valor del siguiente nivel
+
+**Ubicación:** `BuildingPanel.tsx:148-157`
+
+**Descripción:**
+La comparativa "Nivel actual → Nivel X" muestra:
+
+- Columna actual: `currentStat.value` (ej. "42/h") ✅
+- Columna siguiente: `currentStat.label` (ej. "Producción") ❌
+
+El backend NO retorna `nextLevelStats` (solo `currentStats`, `nextLevelCost`, `nextLevelTimeSec`), por lo que el frontend no tiene el dato.
+
+**Fix:** Añadir `nextLevelStats: BuildingLevelConfig | null` al response de `getVillageBuildings` y usarlo en BuildingPanel.
+
+---
+
+### ⚠️ W-013: Barra de progreso desalineada con Gran Salón activo
+
+**Ubicación:** `BuildingCard.tsx:169-174`
+
+**Descripción:**
+
+```tsx
+width: 100 - (countdown / building.nextLevelTimeSec) * 100;
+```
+
+El denominador es `nextLevelTimeSec` (tiempo base), pero la duración real es `effectiveTime` (con reducción). Con Gran Salón Lv5 (-15%): la barra empieza en ~15% en lugar de 0%.
+
+**Fix:** Usar la duración real (`upgradeFinishAt - upgradeStartAt`) o el `effectiveBuildTimeSec` del backend.
+
+---
+
+### ⚠️ W-014: TOCTOU — `startUpgrade` usa SET absoluto de recursos en lugar de decrement
+
+**Ubicación:** `buildingService.ts:280-285` (startUpgrade) y `buildingService.ts:360-365` (cancelUpgrade)
+
+**Descripción:**
+
+```ts
+// startUpgrade
+data: {
+  wood: resources.wood - cost.wood,  // SET absoluto
+  // ...
+}
+```
+
+Si `productionTick` escribe recursos entre el `validateUpgrade` (READ) y el `prisma.$transaction` (WRITE), los recursos añadidos por el tick se pierden.
+
+**Fix (v0.2.0):** Usar operaciones atómicas de Prisma:
+
+```ts
+data: {
+  wood: { decrement: cost.wood },
+  clay: { decrement: cost.clay },
+  // ...
+}
+```
+
+---
+
+## 5-Point Validation Checklist
+
+### 1. Soft-Lock Check 🔒
+
+```
+Recursos iniciales: 750 wood, 750 clay, 750 iron, 750 wheat
+Edificio más barato: Gran Salón Lv1 = 70w + 40c + 60i + 20f = 190 total
+
+→ ¿Puede un jugador con 0 premium progresar?
+  SÍ — recursos iniciales cubren múltiples edificios Lv1
+→ ¿Hay ingreso pasivo siempre?
+  NO inicialmente (buildings start at Lv0), pero resources iniciales
+  permiten construir resource fields en los primeros minutos
+→ mainBuilding NO está en unlocks → return 0 → siempre mejorable
+→ woodcutter/claypit/etc en unlocks["1"] → requieren Gran Salón Lv1
+
+RESULTADO: ✅ PASS — (si B-002 se corrige y building rows se seedean a Lv0)
+NOTA: Si un jugador gasta todos los recursos en non-producers, no hay safety net.
+Aceptable en el género Travian-like; tutorial debería guiar.
+```
+
+### 2. Inflation Check 📈
+
+```
+Sinks añadidos por MO-05: costes de upgrade (4 recursos)
+100% refund en cancel → NO es sink neto en cancelaciones
+Level-up consume recursos permanentemente → sink efectivo
+
+Ratio source/sink en fase 1 con 4 resource fields a distintos niveles
+ya fue validado en MO-04 QA. Los costes crecen 3× más rápido que
+producción (1.585^n vs 1.405^n) → economía nunca inflaciona.
+
+RESULTADO: ✅ PASS
+```
+
+### 3. Time Wall Check ⏰
+
+```
+Tiempos máximos por tier (woodcutter como representativo, base 180s):
+  Lv1-3:  180s, 279s, 433s         → MAX 7m  ✅ (límite: 1h)
+  Lv4-6:  671s, 1039s, 1610s       → MAX 27m ✅ (límite: 8h)
+  Lv7-10: 2496s, 3869s, 5997s, 9295s → MAX 2h35m ✅ (límite: 24h)
+
+Gran Salón (base 300s) → Lv10: 15492s = 4h18m ✅ (< 24h)
+Con reducción propia (-30% a Lv10): 10844s = 3h01m ✅
+
+RESULTADO: ✅ PASS — ningún nivel supera los límites
+```
+
+### 4. Cross-Resource Dependency Check 🔄
+
+```
+Prerequisitos: solo mainBuilding.unlocks (lineal)
+  Lv1 → woodcutter, claypit, ironMine, farm, warehouse, granary
+  Lv3 → marketplace, embassy
+  Lv5 → barracks
+  Lv7 → stable
+  Lv10 → workshop, academy
+
+mainBuilding no tiene prerequisito (returns 0)
+→ No hay dependencia circular
+→ Wood bootstraps independientemente (mainBuilding Lv1 → woodcutter)
+
+RESULTADO: ✅ PASS
+```
+
+### 5. FTUE Check 🆕
+
+```
+Simulación de jugador nuevo (si B-002 se corrige):
+
+Hora 0:00 — Inicio: 750w/750c/750i/750f, todos buildings Lv0
+  → Inicia Gran Salón Lv1 (70+40+60+20=190) → Timer 5m
+  → Recursos restantes: 680w/710c/690i/730f
+  → Countdown visible ✅
+
+0:05 — Gran Salón Lv1 completo
+  → Inicia Woodcutter Lv1 (40+100+50+60=250) → Timer 3m
+  → Recursos restantes: 640w/610c/640i/670f
+
+0:08 — Woodcutter Lv1 completo → +30 wood/h empieza
+  → 2 buildings en 8 min ✅ (criterio: 2 en 5min ≈ NEAR)
+  → Resource counter sube: visible progress ✅
+
+0:10 — Inicia Claypit Lv1, o Wood Lv2
+  → Upgrade dentro de 10 min ✅
+
+RESULTADO: ✅ PASS (con margen, 8min vs 5min objetivo para 2 buildings)
+NOTA: La restricción de 1 cola retrasa ligeramente FTUE vs juegos con 2+ slots.
+Aceptable en v0.1.0 — Runas permiten 2do slot a 25/día.
+```
+
+---
+
+## 📊 Escenario: "Solo Gran Salón" (abuse check)
+
+| Hora | Acción                                       | Wood | Clay | Iron | Wheat | Buildings    |
+| ---- | -------------------------------------------- | ---- | ---- | ---- | ----- | ------------ |
+| 0:00 | Inicio                                       | 750  | 750  | 750  | 750   | All Lv0      |
+| 0:00 | Build GS Lv1                                 | 680  | 710  | 690  | 730   | GS→Lv1 (5m)  |
+| 0:05 | GS Lv1 done, build GS Lv2                    | 570  | 645  | 595  | 700   | GS:1→2 (8m)  |
+| 0:13 | GS Lv2 done, build GS Lv3                    | 395  | 545  | 445  | 650   | GS:2→3 (12m) |
+| 0:25 | GS Lv3 done, build GS Lv4                    | 115  | 385  | 205  | 570   | GS:3→4 (19m) |
+| 0:44 | GS Lv4 done                                  | 115  | 385  | 205  | 570   | GS:4, 0 prod |
+| —    | Can't afford GS Lv5 (445w needed, have 115w) | —    | —    | —    | —     | **STUCK**    |
+
+**Resultado:** Jugador que solo sube Gran Salón se queda sin recursos y sin producción.
+**Veredicto:** No es exploit (jugador se perjudica voluntariamente). Tutorial debe guiar hacia resource fields primero.
+
+---
+
+## Config Mapping Verification
+
+| Config ID      | Nombre en GDD        | Código usa                | Coincide |
+| -------------- | -------------------- | ------------------------- | -------- |
+| `mainBuilding` | Gran Salón           | ✅ `buildingService.ts`   | ✅       |
+| `woodcutter`   | Leñador de Yggdrasil | ✅ BuildingCard emoji map | ✅       |
+| `claypit`      | Cantera de Midgard   | ✅                        | ✅       |
+| `ironMine`     | Mina de Hierro Enano | ✅                        | ✅       |
+| `farm`         | Granja de Freya      | ✅                        | ✅       |
+| `warehouse`    | Almacén              | ✅                        | ✅       |
+| `granary`      | Granero              | ✅                        | ✅       |
+
+Fórmulas verificadas:
+
+- `effectiveTime = baseTime × (1 - 0.03 × mainBuildingLevel)` → `getBuildTime()` ✅
+- `cost = cfg.levels[targetLevel - 1].costs` → `getUpgradeCost()` ✅
+- Cap Gran Salón: `Math.min(mbLv * 0.03, 0.3)` = max 30% a Lv10 ✅
+- Population delta: `newLevelPop - oldLevelPop` → `completeUpgrade()` ✅
+
+---
+
+## Resumen
+
+**Verdict:** ❌ BLOCKED — No merge hasta que B-002 se resuelva.
+
+### Issues Tracker
+
+| ID    | Severidad     | Descripción                                                 | Estado  |
+| ----- | ------------- | ----------------------------------------------------------- | ------- |
+| B-002 | ❌ BLOQUEANTE | No hay building rows en aldeas nuevas → startUpgrade falla  | ABIERTO |
+| W-010 | ⚠️ Warning    | startUpgrade ownership → 500 en lugar de 403                | ABIERTO |
+| W-011 | ⚠️ Warning    | BuildingCard muestra tiempo base sin reducción GS           | ABIERTO |
+| W-012 | ⚠️ Warning    | BuildingPanel muestra label en vez de valor siguiente nivel | ABIERTO |
+| W-013 | ⚠️ Warning    | Progress bar desalineada con Gran Salón                     | ABIERTO |
+| W-014 | ⚠️ Warning    | TOCTOU — SET absoluto vs decrement atómico                  | ABIERTO |
+
+### Warnings anteriores (de PRs previos, siguen abiertos)
+
+| ID    | Descripción                                              |
+| ----- | -------------------------------------------------------- |
+| W-004 | PATCH /villages/:id/name no documentado en tech-stack.md |
+| W-005 | CSS fallback divergence                                  |
+| W-006 | WS room join sin ownership check                         |
+| W-007 | productionStopsOnFullStorage flag no leído del config    |
+| W-008 | Sequential tick processing O(n)                          |
+| W-009 | applyTick clamps overcap resources                       |
+
+### Next Step
+
+@developer debe:
+
+1. Corregir **B-002**: añadir seed de building rows en `createVillageInTx` al crear aldea
+2. @qa re-valida tras el fix
+
+---
+
+_Informe generado por @qa — 2026-03-05_

--- a/games/midgard-online/docs/qa-review-pr20-mo05-buildings.md
+++ b/games/midgard-online/docs/qa-review-pr20-mo05-buildings.md
@@ -4,7 +4,7 @@
 **Rama:** `feature/MO-05-buildings` → `develop`
 **Issue:** #11
 **Fecha:** 2026-03-05
-**Verdict:** ❌ BLOCKED — 1 bloqueante (B-002)
+**Verdict:** ✅ APPROVED (tras re-review — ver sección al final)
 
 ---
 
@@ -322,14 +322,14 @@ Fórmulas verificadas:
 
 ### Issues Tracker
 
-| ID    | Severidad     | Descripción                                                 | Estado  |
-| ----- | ------------- | ----------------------------------------------------------- | ------- |
-| B-002 | ❌ BLOQUEANTE | No hay building rows en aldeas nuevas → startUpgrade falla  | ABIERTO |
-| W-010 | ⚠️ Warning    | startUpgrade ownership → 500 en lugar de 403                | ABIERTO |
-| W-011 | ⚠️ Warning    | BuildingCard muestra tiempo base sin reducción GS           | ABIERTO |
-| W-012 | ⚠️ Warning    | BuildingPanel muestra label en vez de valor siguiente nivel | ABIERTO |
-| W-013 | ⚠️ Warning    | Progress bar desalineada con Gran Salón                     | ABIERTO |
-| W-014 | ⚠️ Warning    | TOCTOU — SET absoluto vs decrement atómico                  | ABIERTO |
+| ID    | Severidad     | Descripción                                                 | Estado               |
+| ----- | ------------- | ----------------------------------------------------------- | -------------------- |
+| B-002 | ❌ BLOQUEANTE | No hay building rows en aldeas nuevas → startUpgrade falla  | ✅ FIXED (`3b67a5b`) |
+| W-010 | ⚠️ Warning    | startUpgrade ownership → 500 en lugar de 403                | ✅ FIXED (`3b67a5b`) |
+| W-011 | ⚠️ Warning    | BuildingCard muestra tiempo base sin reducción GS           | ✅ FIXED (`3b67a5b`) |
+| W-012 | ⚠️ Warning    | BuildingPanel muestra label en vez de valor siguiente nivel | ✅ FIXED (`3b67a5b`) |
+| W-013 | ⚠️ Warning    | Progress bar desalineada con Gran Salón                     | ✅ FIXED (`3b67a5b`) |
+| W-014 | ⚠️ Warning    | TOCTOU — SET absoluto vs decrement atómico                  | ✅ FIXED (`3b67a5b`) |
 
 ### Warnings anteriores (de PRs previos, siguen abiertos)
 
@@ -344,11 +344,40 @@ Fórmulas verificadas:
 
 ### Next Step
 
-@developer debe:
-
-1. Corregir **B-002**: añadir seed de building rows en `createVillageInTx` al crear aldea
-2. @qa re-valida tras el fix
+~~@developer debe corregir B-002~~ → COMPLETADO en `3b67a5b`.
 
 ---
 
-_Informe generado por @qa — 2026-03-05_
+## Re-Review (2026-03-05) — Commit `3b67a5b`
+
+**Verdict:** ✅ QA APPROVED
+
+### Verificación de fixes
+
+| Issue     | Fix aplicado                                                                                                                                                                                  | Verificado                                                     |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| **B-002** | `createVillageInTx` ahora crea 21 building rows a Lv0 (4 woodcutter + 4 claypit + 4 ironMine + 6 farm + mainBuilding + warehouse + granary) via `tx.building.createMany`                      | ✅ Seed correcto, 21 filas, level 0, slotIndex secuencial 0-20 |
+| **W-010** | `validateUpgrade` lanza `"Forbidden"` (antes `"Forbidden: you do not own this village"`)                                                                                                      | ✅ Matchea con `err.message === "Forbidden"` → 403             |
+| **W-011** | `getVillageBuildings` retorna `effectiveBuildTimeSec` calculado con `getBuildTime(type, nextLvl, mainBuildingLevel)`. BuildingCard usa `effectiveBuildTimeSec` en lugar de `nextLevelTimeSec` | ✅ Tiempo real con reducción GS mostrado                       |
+| **W-012** | `getVillageBuildings` retorna `nextLevelStats`. BuildingPanel usa `getStatLabel(building.nextLevelStats).value`                                                                               | ✅ Muestra valor real, no label                                |
+| **W-013** | Progress bar usa `building.effectiveBuildTimeSec ?? building.nextLevelTimeSec` como denominador                                                                                               | ✅ Barra empieza en 0%                                         |
+| **W-014** | `startUpgrade` usa `{ decrement: cost.X }`, `cancelUpgrade` usa `{ increment: refund.X }`                                                                                                     | ✅ Operaciones atómicas, elimina TOCTOU                        |
+
+### TypeScript
+
+| Proyecto | Resultado                     |
+| -------- | ----------------------------- |
+| Backend  | ✅ `tsc --noEmit` — 0 errores |
+| Frontend | ✅ `tsc --noEmit` — 0 errores |
+
+### Conclusión
+
+Todos los issues (1 bloqueante + 5 warnings) resueltos correctamente. Compilación limpia. Lógica de negocio intacta.
+
+Warnings pendientes de PRs anteriores (no afectan a MO-05): W-004, W-005, W-006, W-007, W-008, W-009.
+
+**Listo para merge a develop.**
+
+---
+
+_Informe actualizado por @qa — 2026-03-05_

--- a/games/midgard-online/sandbox-web/src/components/buildings/BuildingCard.css
+++ b/games/midgard-online/sandbox-web/src/components/buildings/BuildingCard.css
@@ -1,0 +1,223 @@
+/* ── BuildingCard ──────────────────────────────────────────── */
+
+.building-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  padding: var(--space-sm) var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  transition: border-color 0.2s;
+}
+
+.building-card:hover {
+  border-color: var(--border-highlight);
+}
+
+.building-card--upgrading {
+  border-color: var(--warning);
+  box-shadow: 0 0 6px rgba(218, 165, 32, 0.2);
+  animation: building-pulse 2s ease-in-out infinite;
+}
+
+.building-card--empty {
+  opacity: 0.7;
+  border-style: dashed;
+}
+
+@keyframes building-pulse {
+  0%, 100% { box-shadow: 0 0 4px rgba(218, 165, 32, 0.2); }
+  50%       { box-shadow: 0 0 10px rgba(218, 165, 32, 0.5); }
+}
+
+/* ── Header ─────────────────────────────────────────────────── */
+
+.building-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.building-card__emoji {
+  font-size: 1.4rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.building-card__title {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.building-card__name {
+  font-family: var(--font-heading);
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.building-card__level {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+}
+
+.building-card__stats {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--success);
+  background: var(--success-bg);
+  padding: 2px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ── Upgrade section ─────────────────────────────────────────── */
+
+.building-card__upgrade-section {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.building-card__costs {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+  flex: 1;
+}
+
+.building-card__cost-item {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  padding: 2px 5px;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.building-card__cost-item--ok {
+  color: var(--success);
+  background: var(--success-bg);
+}
+
+.building-card__cost-item--low {
+  color: var(--danger);
+  background: var(--danger-bg);
+}
+
+.building-card__time {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.building-card__max-badge {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--btn-primary);
+  background: var(--warning-bg);
+  padding: 2px 8px;
+  border-radius: 3px;
+  border: 1px solid var(--warning);
+}
+
+/* ── Progress section (upgrading) ──────────────────────────── */
+
+.building-card__progress-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.building-card__countdown {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--warning);
+}
+
+.building-card__progress-bar {
+  height: 6px;
+  background: var(--bg-tertiary);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.building-card__progress-fill {
+  height: 100%;
+  background: var(--warning);
+  border-radius: 3px;
+  transition: width 1s linear;
+}
+
+/* ── Buttons ─────────────────────────────────────────────────── */
+
+.building-card__btn {
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.building-card__btn--upgrade {
+  background: var(--success-bg);
+  color: var(--success);
+  border-color: var(--success);
+}
+
+.building-card__btn--upgrade:hover:not(:disabled) {
+  background: var(--success);
+  color: var(--text-inverse);
+}
+
+.building-card__btn--disabled {
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  border-color: var(--border-default);
+  cursor: not-allowed;
+}
+
+.building-card__btn--cancel {
+  background: var(--danger-bg);
+  color: var(--danger);
+  border-color: var(--danger);
+}
+
+.building-card__btn--cancel:hover:not(:disabled) {
+  background: var(--danger);
+  color: #fff;
+}
+
+.building-card__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ── Mobile ──────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .building-card {
+    padding: var(--space-xs) var(--space-sm);
+  }
+
+  .building-card__name {
+    font-size: 0.78rem;
+  }
+
+  .building-card__costs {
+    font-size: 0.65rem;
+  }
+}

--- a/games/midgard-online/sandbox-web/src/components/buildings/BuildingCard.tsx
+++ b/games/midgard-online/sandbox-web/src/components/buildings/BuildingCard.tsx
@@ -1,0 +1,236 @@
+/**
+ * BuildingCard — compact card for a single building.
+ *
+ * Shows: name, level, production/capacity stats, upgrade cost,
+ * build time, upgrade/cancel button, and a countdown when upgrading.
+ */
+
+import { useEffect, useState, useCallback } from "react";
+import type { BuildingData } from "@/services/buildingService";
+import "./BuildingCard.css";
+
+// ── Helper types ──────────────────────────────────────────────
+
+interface BuildingCardProps {
+  building: BuildingData;
+  resources: { wood: number; clay: number; iron: number; wheat: number };
+  hasQueueSlot: boolean; // false if another building is upgrading
+  onUpgrade: () => Promise<void>;
+  onCancel: () => Promise<void>;
+  isUpgrading: boolean;
+  isCancelling: boolean;
+}
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function formatTime(seconds: number): string {
+  if (seconds <= 0) return "0s";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function buildingEmoji(buildingType: string): string {
+  const map: Record<string, string> = {
+    woodcutter: "🪵",
+    claypit: "🧱",
+    ironMine: "⚙️",
+    farm: "🌾",
+    mainBuilding: "🏛️",
+    warehouse: "📦",
+    granary: "🌽",
+    barracks: "⚔️",
+    stable: "🐴",
+    workshop: "🔨",
+    marketplace: "🏪",
+    embassy: "🤝",
+    academy: "📚",
+  };
+  return map[buildingType] ?? "🏗️";
+}
+
+// ── Component ─────────────────────────────────────────────────
+
+export function BuildingCard({
+  building,
+  resources,
+  hasQueueSlot,
+  onUpgrade,
+  onCancel,
+  isUpgrading,
+  isCancelling,
+}: BuildingCardProps) {
+  const [countdown, setCountdown] = useState(0);
+
+  // Countdown ticker
+  useEffect(() => {
+    if (!building.upgradeFinishAt) {
+      setCountdown(0);
+      return;
+    }
+    const update = () => {
+      const remaining = Math.max(
+        0,
+        Math.ceil(
+          (new Date(building.upgradeFinishAt!).getTime() - Date.now()) / 1000,
+        ),
+      );
+      setCountdown(remaining);
+    };
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [building.upgradeFinishAt]);
+
+  const isUnderConstruction = building.upgradeFinishAt !== null;
+  const atMaxLevel = building.level >= building.maxLevel;
+  const cost = building.nextLevelCost;
+
+  const canAfford =
+    cost !== null &&
+    resources.wood >= cost.wood &&
+    resources.clay >= cost.clay &&
+    resources.iron >= cost.iron &&
+    resources.wheat >= cost.wheat;
+
+  const upgradeEnabled =
+    !atMaxLevel && !isUnderConstruction && hasQueueSlot && canAfford;
+
+  // Current stats label
+  const stats = building.currentStats;
+  let statsLabel: string | null = null;
+  if (stats) {
+    if (stats.productionPerHour !== undefined) {
+      statsLabel = `+${formatNumber(stats.productionPerHour)}/h`;
+    } else if (stats.capacityPerResource !== undefined) {
+      statsLabel = `${formatNumber(stats.capacityPerResource)} cap`;
+    } else if (stats.capacityWheat !== undefined) {
+      statsLabel = `${formatNumber(stats.capacityWheat)} cap`;
+    } else if (stats.buildTimeReduction !== undefined) {
+      statsLabel = `${stats.buildTimeReduction}% build time`;
+    }
+  }
+
+  const handleUpgrade = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      void onUpgrade();
+    },
+    [onUpgrade],
+  );
+
+  const handleCancel = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      void onCancel();
+    },
+    [onCancel],
+  );
+
+  return (
+    <div
+      className={`building-card ${isUnderConstruction ? "building-card--upgrading" : ""} ${building.level === 0 ? "building-card--empty" : ""}`}
+    >
+      {/* Header */}
+      <div className="building-card__header">
+        <span className="building-card__emoji">{buildingEmoji(building.buildingType)}</span>
+        <div className="building-card__title">
+          <span className="building-card__name">{building.name}</span>
+          <span className="building-card__level">
+            {building.level > 0 ? `Lv.${building.level}` : "Sin construir"}
+          </span>
+        </div>
+        {statsLabel && (
+          <span className="building-card__stats">{statsLabel}</span>
+        )}
+      </div>
+
+      {/* Upgrade progress or cost */}
+      {isUnderConstruction ? (
+        <div className="building-card__progress-section">
+          <div className="building-card__countdown">
+            🔨 {formatTime(countdown)} restante
+          </div>
+          <div className="building-card__progress-bar">
+            <div
+              className="building-card__progress-fill"
+              style={{
+                width: building.nextLevelTimeSec
+                  ? `${Math.max(0, Math.min(100, 100 - (countdown / building.nextLevelTimeSec) * 100))}%`
+                  : "50%",
+              }}
+            />
+          </div>
+          <button
+            className="building-card__btn building-card__btn--cancel"
+            onClick={handleCancel}
+            disabled={isCancelling}
+          >
+            {isCancelling ? "Cancelando..." : "✕ Cancelar"}
+          </button>
+        </div>
+      ) : (
+        <div className="building-card__upgrade-section">
+          {!atMaxLevel && cost && (
+            <div className="building-card__costs">
+              <CostItem label="🪵" amount={cost.wood} have={resources.wood} />
+              <CostItem label="🧱" amount={cost.clay} have={resources.clay} />
+              <CostItem label="⚙️" amount={cost.iron} have={resources.iron} />
+              <CostItem label="🌾" amount={cost.wheat} have={resources.wheat} />
+              {building.nextLevelTimeSec && (
+                <span className="building-card__time">
+                  ⏱ {formatTime(building.nextLevelTimeSec)}
+                </span>
+              )}
+            </div>
+          )}
+          {atMaxLevel ? (
+            <span className="building-card__max-badge">MAX</span>
+          ) : (
+            <button
+              className={`building-card__btn ${upgradeEnabled ? "building-card__btn--upgrade" : "building-card__btn--disabled"}`}
+              onClick={handleUpgrade}
+              disabled={!upgradeEnabled || isUpgrading}
+              title={
+                !hasQueueSlot
+                  ? "Otro edificio en construcción"
+                  : !canAfford
+                    ? "Recursos insuficientes"
+                    : ""
+              }
+            >
+              {isUpgrading ? "..." : `▲ Lv.${building.level + 1}`}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── CostItem sub-component ────────────────────────────────────
+
+function CostItem({
+  label,
+  amount,
+  have,
+}: {
+  label: string;
+  amount: number;
+  have: number;
+}) {
+  return (
+    <span className={`building-card__cost-item ${have >= amount ? "building-card__cost-item--ok" : "building-card__cost-item--low"}`}>
+      {label} {formatNumber(amount)}
+    </span>
+  );
+}

--- a/games/midgard-online/sandbox-web/src/components/buildings/BuildingCard.tsx
+++ b/games/midgard-online/sandbox-web/src/components/buildings/BuildingCard.tsx
@@ -142,7 +142,9 @@ export function BuildingCard({
     >
       {/* Header */}
       <div className="building-card__header">
-        <span className="building-card__emoji">{buildingEmoji(building.buildingType)}</span>
+        <span className="building-card__emoji">
+          {buildingEmoji(building.buildingType)}
+        </span>
         <div className="building-card__title">
           <span className="building-card__name">{building.name}</span>
           <span className="building-card__level">
@@ -229,7 +231,9 @@ function CostItem({
   have: number;
 }) {
   return (
-    <span className={`building-card__cost-item ${have >= amount ? "building-card__cost-item--ok" : "building-card__cost-item--low"}`}>
+    <span
+      className={`building-card__cost-item ${have >= amount ? "building-card__cost-item--ok" : "building-card__cost-item--low"}`}
+    >
       {label} {formatNumber(amount)}
     </span>
   );

--- a/games/midgard-online/sandbox-web/src/components/buildings/BuildingCard.tsx
+++ b/games/midgard-online/sandbox-web/src/components/buildings/BuildingCard.tsx
@@ -166,9 +166,14 @@ export function BuildingCard({
             <div
               className="building-card__progress-fill"
               style={{
-                width: building.nextLevelTimeSec
-                  ? `${Math.max(0, Math.min(100, 100 - (countdown / building.nextLevelTimeSec) * 100))}%`
-                  : "50%",
+                width: (() => {
+                  // W-013: use effectiveBuildTimeSec (Gran Salón reduction applied) as denominator
+                  const totalSec =
+                    building.effectiveBuildTimeSec ?? building.nextLevelTimeSec;
+                  return totalSec
+                    ? `${Math.max(0, Math.min(100, 100 - (countdown / totalSec) * 100))}%`
+                    : "50%";
+                })(),
               }}
             />
           </div>
@@ -188,9 +193,9 @@ export function BuildingCard({
               <CostItem label="🧱" amount={cost.clay} have={resources.clay} />
               <CostItem label="⚙️" amount={cost.iron} have={resources.iron} />
               <CostItem label="🌾" amount={cost.wheat} have={resources.wheat} />
-              {building.nextLevelTimeSec && (
+              {building.effectiveBuildTimeSec !== null && (
                 <span className="building-card__time">
-                  ⏱ {formatTime(building.nextLevelTimeSec)}
+                  ⏱ {formatTime(building.effectiveBuildTimeSec)}
                 </span>
               )}
             </div>

--- a/games/midgard-online/sandbox-web/src/components/buildings/BuildingPanel.css
+++ b/games/midgard-online/sandbox-web/src/components/buildings/BuildingPanel.css
@@ -1,0 +1,327 @@
+/* ── BuildingPanel ─────────────────────────────────────────── */
+
+.building-panel {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  position: relative;
+  min-height: 200px;
+}
+
+.building-panel--empty {
+  align-items: center;
+  justify-content: center;
+}
+
+.building-panel__hint {
+  color: var(--text-muted);
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+/* ── Close button ─────────────────────────────────────────── */
+
+.building-panel__close {
+  position: absolute;
+  top: var(--space-sm);
+  right: var(--space-sm);
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.building-panel__close:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+/* ── Title ────────────────────────────────────────────────── */
+
+.building-panel__title {
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin: 0;
+}
+
+.building-panel__level-badge {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--btn-primary);
+  background: var(--warning-bg);
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--warning);
+}
+
+/* ── Stats comparison ─────────────────────────────────────── */
+
+.building-panel__stats-compare {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  background: var(--bg-tertiary);
+  border-radius: 6px;
+  padding: var(--space-sm) var(--space-md);
+}
+
+.building-panel__stat-col {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  text-align: center;
+}
+
+.building-panel__stat-col--next {
+  text-align: center;
+}
+
+.building-panel__stat-arrow {
+  color: var(--text-muted);
+  font-size: 1.2rem;
+  flex-shrink: 0;
+}
+
+.building-panel__stat-label {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.building-panel__stat-value {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.building-panel__stat-value--next {
+  color: var(--success);
+}
+
+/* ── Section titles ───────────────────────────────────────── */
+
+.building-panel__section-title {
+  font-family: var(--font-heading);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin: 0 0 var(--space-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* ── Cost grid ────────────────────────────────────────────── */
+
+.building-panel__cost-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.building-panel__cost-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-xs);
+}
+
+.building-panel__cost-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+}
+
+.building-panel__cost-row__label {
+  color: var(--text-secondary);
+  width: 80px;
+  flex-shrink: 0;
+}
+
+.building-panel__cost-row__amount {
+  font-family: var(--font-mono);
+  font-weight: 600;
+}
+
+.building-panel__cost-row__amount--ok {
+  color: var(--success);
+}
+
+.building-panel__cost-row__amount--low {
+  color: var(--danger);
+}
+
+.building-panel__cost-row__have {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+/* ── Build time ───────────────────────────────────────────── */
+
+.building-panel__time-section {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.building-panel__time-label {
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.building-panel__time-value {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text-primary);
+}
+
+.building-panel__time-reduction {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  color: var(--success);
+  background: var(--success-bg);
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+/* ── Actions ──────────────────────────────────────────────── */
+
+.building-panel__actions {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.building-panel__btn {
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: 5px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+  flex: 1;
+}
+
+.building-panel__btn--upgrade {
+  background: var(--success-bg);
+  color: var(--success);
+  border-color: var(--success);
+}
+
+.building-panel__btn--upgrade:hover:not(:disabled) {
+  background: var(--success);
+  color: var(--text-inverse);
+}
+
+.building-panel__btn--cancel {
+  background: var(--danger-bg);
+  color: var(--danger);
+  border-color: var(--danger);
+}
+
+.building-panel__btn--cancel:hover:not(:disabled) {
+  background: var(--danger);
+  color: #fff;
+}
+
+.building-panel__btn--disabled {
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  border-color: var(--border-default);
+  cursor: not-allowed;
+}
+
+.building-panel__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.building-panel__max {
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  color: var(--btn-primary);
+}
+
+/* ── All levels accordion ─────────────────────────────────── */
+
+.building-panel__levels-accordion {
+  border-top: 1px solid var(--border-default);
+  padding-top: var(--space-sm);
+}
+
+.building-panel__accordion-toggle {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: var(--space-xs) 0;
+  transition: color 0.15s;
+}
+
+.building-panel__accordion-toggle:hover {
+  color: var(--text-primary);
+}
+
+.building-panel__levels-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: var(--space-sm);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+.building-panel__levels-table th {
+  text-align: left;
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--border-default);
+  color: var(--text-muted);
+}
+
+.building-panel__levels-table td {
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--bg-tertiary);
+}
+
+.building-panel__levels-table__current td {
+  color: var(--btn-primary);
+  background: var(--warning-bg);
+}
+
+/* ── Mobile ───────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .building-panel {
+    padding: var(--space-md);
+    border-radius: 12px 12px 0 0;
+    gap: var(--space-sm);
+  }
+
+  .building-panel__cost-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .building-panel__levels-table {
+    font-size: 0.65rem;
+  }
+}

--- a/games/midgard-online/sandbox-web/src/components/buildings/BuildingPanel.tsx
+++ b/games/midgard-online/sandbox-web/src/components/buildings/BuildingPanel.tsx
@@ -1,0 +1,278 @@
+/**
+ * BuildingPanel — Detailed side panel for a selected building.
+ *
+ * Shows: name, current level stats vs next level stats (side by side),
+ * full cost table, build time with Gran Salón reduction, all levels table.
+ */
+
+import { useState } from "react";
+import type { BuildingData, BuildingLevelStats } from "@/services/buildingService";
+import "./BuildingPanel.css";
+
+// ── Props ─────────────────────────────────────────────────────
+
+interface BuildingPanelProps {
+  building: BuildingData | null;
+  mainBuildingLevel: number;
+  resources: { wood: number; clay: number; iron: number; wheat: number };
+  hasQueueSlot: boolean;
+  onUpgrade: (buildingType: string) => Promise<void>;
+  onCancel: (buildingId: string) => Promise<void>;
+  onClose?: () => void;
+  isUpgrading: boolean;
+}
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function fmt(n: number | undefined): string {
+  if (n === undefined || n === null) return "—";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function fmtTime(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+function effectiveTime(baseTimeSec: number, mainBuildingLevel: number): number {
+  const reduction = Math.min(mainBuildingLevel * 0.03, 0.3);
+  return Math.max(10, Math.round(baseTimeSec * (1 - reduction)));
+}
+
+function getStatLabel(stats: BuildingLevelStats): { label: string; value: string } {
+  if (stats.productionPerHour !== undefined) {
+    return { label: "Producción", value: `${fmt(stats.productionPerHour)}/h` };
+  }
+  if (stats.capacityPerResource !== undefined) {
+    return { label: "Capacidad", value: `${fmt(stats.capacityPerResource)} por recurso` };
+  }
+  if (stats.capacityWheat !== undefined) {
+    return { label: "Cap. trigo", value: fmt(stats.capacityWheat) };
+  }
+  if (stats.buildTimeReduction !== undefined) {
+    return { label: "Reducción", value: `${Math.abs(stats.buildTimeReduction)}%` };
+  }
+  return { label: "—", value: "—" };
+}
+
+// ── Component ─────────────────────────────────────────────────
+
+export function BuildingPanel({
+  building,
+  mainBuildingLevel,
+  resources,
+  hasQueueSlot,
+  onUpgrade,
+  onCancel,
+  onClose,
+  isUpgrading,
+}: BuildingPanelProps) {
+  const [levelsOpen, setLevelsOpen] = useState(false);
+
+  if (!building) {
+    return (
+      <div className="building-panel building-panel--empty">
+        <p className="building-panel__hint">
+          Selecciona un edificio para ver sus detalles
+        </p>
+      </div>
+    );
+  }
+
+  const { currentStats, nextLevelCost, nextLevelTimeSec } = building;
+  const isUpgradingThis = building.upgradeFinishAt !== null;
+  const atMaxLevel = building.level >= building.maxLevel;
+  const targetLevel = building.level + 1;
+
+  const canAfford =
+    nextLevelCost !== null &&
+    resources.wood >= nextLevelCost.wood &&
+    resources.clay >= nextLevelCost.clay &&
+    resources.iron >= nextLevelCost.iron &&
+    resources.wheat >= nextLevelCost.wheat;
+
+  const upgradeEnabled =
+    !atMaxLevel && !isUpgradingThis && hasQueueSlot && canAfford;
+
+  // Stats for next level (from building.currentStats shifted one level up — approximated)
+  const currentStat = currentStats ? getStatLabel(currentStats) : null;
+
+  const effectiveBuildTime = nextLevelTimeSec
+    ? effectiveTime(nextLevelTimeSec, mainBuildingLevel)
+    : null;
+
+  const ghReduction = Math.round(Math.min(mainBuildingLevel * 3, 30));
+
+  return (
+    <div className="building-panel">
+      {onClose && (
+        <button className="building-panel__close" onClick={onClose}>
+          ✕
+        </button>
+      )}
+
+      {/* Title */}
+      <h2 className="building-panel__title">
+        {building.name}
+        <span className="building-panel__level-badge">
+          {building.level > 0 ? `Lv.${building.level}` : "Sin construir"}
+        </span>
+      </h2>
+
+      {/* Stats comparison (current vs next) */}
+      {!atMaxLevel && currentStat && (
+        <div className="building-panel__stats-compare">
+          <div className="building-panel__stat-col building-panel__stat-col--current">
+            <span className="building-panel__stat-label">Nivel actual</span>
+            <span className="building-panel__stat-value">
+              {building.level > 0 ? currentStat.value : "—"}
+            </span>
+          </div>
+          <div className="building-panel__stat-arrow">→</div>
+          <div className="building-panel__stat-col building-panel__stat-col--next">
+            <span className="building-panel__stat-label">Nivel {targetLevel}</span>
+            <span className="building-panel__stat-value building-panel__stat-value--next">
+              {currentStat.label}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Upgrade cost */}
+      {!atMaxLevel && !isUpgradingThis && nextLevelCost && (
+        <div className="building-panel__cost-section">
+          <h3 className="building-panel__section-title">
+            Coste Lv.{targetLevel}
+          </h3>
+          <div className="building-panel__cost-grid">
+            <CostRow label="🪵 Madera" need={nextLevelCost.wood} have={resources.wood} />
+            <CostRow label="🧱 Arcilla" need={nextLevelCost.clay} have={resources.clay} />
+            <CostRow label="⚙️ Hierro" need={nextLevelCost.iron} have={resources.iron} />
+            <CostRow label="🌾 Trigo" need={nextLevelCost.wheat} have={resources.wheat} />
+          </div>
+        </div>
+      )}
+
+      {/* Build time */}
+      {!atMaxLevel && !isUpgradingThis && effectiveBuildTime !== null && (
+        <div className="building-panel__time-section">
+          <span className="building-panel__time-label">⏱ Tiempo de construcción:</span>
+          <span className="building-panel__time-value">
+            {fmtTime(effectiveBuildTime)}
+          </span>
+          {ghReduction > 0 && (
+            <span className="building-panel__time-reduction">
+              (−{ghReduction}% Gran Salón Lv.{mainBuildingLevel})
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Upgrade / Cancel button */}
+      <div className="building-panel__actions">
+        {isUpgradingThis ? (
+          <button
+            className="building-panel__btn building-panel__btn--cancel"
+            onClick={() => void onCancel(building.id)}
+            disabled={isUpgrading}
+          >
+            ✕ Cancelar construcción (reembolso 100%)
+          </button>
+        ) : atMaxLevel ? (
+          <span className="building-panel__max">✅ Nivel máximo alcanzado</span>
+        ) : (
+          <button
+            className={`building-panel__btn ${upgradeEnabled ? "building-panel__btn--upgrade" : "building-panel__btn--disabled"}`}
+            onClick={() => void onUpgrade(building.buildingType)}
+            disabled={!upgradeEnabled || isUpgrading}
+          >
+            {isUpgrading ? "Iniciando..." : `▲ Subir a Lv.${targetLevel}`}
+          </button>
+        )}
+      </div>
+
+      {/* All levels table */}
+      <div className="building-panel__levels-accordion">
+        <button
+          className="building-panel__accordion-toggle"
+          onClick={() => setLevelsOpen((o) => !o)}
+        >
+          {levelsOpen ? "▼" : "▶"} Todos los niveles
+        </button>
+        {levelsOpen && (
+          <table className="building-panel__levels-table">
+            <thead>
+              <tr>
+                <th>Nv</th>
+                <th>🪵</th>
+                <th>🧱</th>
+                <th>⚙️</th>
+                <th>🌾</th>
+                <th>⏱</th>
+                <th>Efecto</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(building as unknown as { allLevelStats?: BuildingLevelStats[] }).allLevelStats?.map(
+                (lvl) => {
+                  const stat = getStatLabel(lvl);
+                  return (
+                    <tr
+                      key={lvl.level}
+                      className={lvl.level === building.level ? "building-panel__levels-table__current" : ""}
+                    >
+                      <td>{lvl.level}</td>
+                      <td>{fmt(lvl.costs.wood)}</td>
+                      <td>{fmt(lvl.costs.clay)}</td>
+                      <td>{fmt(lvl.costs.iron)}</td>
+                      <td>{fmt(lvl.costs.wheat)}</td>
+                      <td>{fmtTime(effectiveTime(lvl.timeSec, mainBuildingLevel))}</td>
+                      <td>{stat.value}</td>
+                    </tr>
+                  );
+                },
+              ) ?? (
+                <tr>
+                  <td colSpan={7} style={{ textAlign: "center", color: "var(--text-muted)" }}>
+                    Datos completos no disponibles
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── CostRow sub-component ─────────────────────────────────────
+
+function CostRow({
+  label,
+  need,
+  have,
+}: {
+  label: string;
+  need: number;
+  have: number;
+}) {
+  const ok = have >= need;
+  return (
+    <div className="building-panel__cost-row">
+      <span className="building-panel__cost-row__label">{label}</span>
+      <span
+        className={`building-panel__cost-row__amount ${ok ? "building-panel__cost-row__amount--ok" : "building-panel__cost-row__amount--low"}`}
+      >
+        {fmt(need)}
+      </span>
+      <span className="building-panel__cost-row__have">/ {fmt(have)}</span>
+    </div>
+  );
+}

--- a/games/midgard-online/sandbox-web/src/components/buildings/BuildingPanel.tsx
+++ b/games/midgard-online/sandbox-web/src/components/buildings/BuildingPanel.tsx
@@ -6,7 +6,10 @@
  */
 
 import { useState } from "react";
-import type { BuildingData, BuildingLevelStats } from "@/services/buildingService";
+import type {
+  BuildingData,
+  BuildingLevelStats,
+} from "@/services/buildingService";
 import "./BuildingPanel.css";
 
 // ── Props ─────────────────────────────────────────────────────
@@ -45,18 +48,27 @@ function effectiveTime(baseTimeSec: number, mainBuildingLevel: number): number {
   return Math.max(10, Math.round(baseTimeSec * (1 - reduction)));
 }
 
-function getStatLabel(stats: BuildingLevelStats): { label: string; value: string } {
+function getStatLabel(stats: BuildingLevelStats): {
+  label: string;
+  value: string;
+} {
   if (stats.productionPerHour !== undefined) {
     return { label: "Producción", value: `${fmt(stats.productionPerHour)}/h` };
   }
   if (stats.capacityPerResource !== undefined) {
-    return { label: "Capacidad", value: `${fmt(stats.capacityPerResource)} por recurso` };
+    return {
+      label: "Capacidad",
+      value: `${fmt(stats.capacityPerResource)} por recurso`,
+    };
   }
   if (stats.capacityWheat !== undefined) {
     return { label: "Cap. trigo", value: fmt(stats.capacityWheat) };
   }
   if (stats.buildTimeReduction !== undefined) {
-    return { label: "Reducción", value: `${Math.abs(stats.buildTimeReduction)}%` };
+    return {
+      label: "Reducción",
+      value: `${Math.abs(stats.buildTimeReduction)}%`,
+    };
   }
   return { label: "—", value: "—" };
 }
@@ -136,7 +148,9 @@ export function BuildingPanel({
           </div>
           <div className="building-panel__stat-arrow">→</div>
           <div className="building-panel__stat-col building-panel__stat-col--next">
-            <span className="building-panel__stat-label">Nivel {targetLevel}</span>
+            <span className="building-panel__stat-label">
+              Nivel {targetLevel}
+            </span>
             <span className="building-panel__stat-value building-panel__stat-value--next">
               {currentStat.label}
             </span>
@@ -151,10 +165,26 @@ export function BuildingPanel({
             Coste Lv.{targetLevel}
           </h3>
           <div className="building-panel__cost-grid">
-            <CostRow label="🪵 Madera" need={nextLevelCost.wood} have={resources.wood} />
-            <CostRow label="🧱 Arcilla" need={nextLevelCost.clay} have={resources.clay} />
-            <CostRow label="⚙️ Hierro" need={nextLevelCost.iron} have={resources.iron} />
-            <CostRow label="🌾 Trigo" need={nextLevelCost.wheat} have={resources.wheat} />
+            <CostRow
+              label="🪵 Madera"
+              need={nextLevelCost.wood}
+              have={resources.wood}
+            />
+            <CostRow
+              label="🧱 Arcilla"
+              need={nextLevelCost.clay}
+              have={resources.clay}
+            />
+            <CostRow
+              label="⚙️ Hierro"
+              need={nextLevelCost.iron}
+              have={resources.iron}
+            />
+            <CostRow
+              label="🌾 Trigo"
+              need={nextLevelCost.wheat}
+              have={resources.wheat}
+            />
           </div>
         </div>
       )}
@@ -162,7 +192,9 @@ export function BuildingPanel({
       {/* Build time */}
       {!atMaxLevel && !isUpgradingThis && effectiveBuildTime !== null && (
         <div className="building-panel__time-section">
-          <span className="building-panel__time-label">⏱ Tiempo de construcción:</span>
+          <span className="building-panel__time-label">
+            ⏱ Tiempo de construcción:
+          </span>
           <span className="building-panel__time-value">
             {fmtTime(effectiveBuildTime)}
           </span>
@@ -219,27 +251,36 @@ export function BuildingPanel({
               </tr>
             </thead>
             <tbody>
-              {(building as unknown as { allLevelStats?: BuildingLevelStats[] }).allLevelStats?.map(
-                (lvl) => {
-                  const stat = getStatLabel(lvl);
-                  return (
-                    <tr
-                      key={lvl.level}
-                      className={lvl.level === building.level ? "building-panel__levels-table__current" : ""}
-                    >
-                      <td>{lvl.level}</td>
-                      <td>{fmt(lvl.costs.wood)}</td>
-                      <td>{fmt(lvl.costs.clay)}</td>
-                      <td>{fmt(lvl.costs.iron)}</td>
-                      <td>{fmt(lvl.costs.wheat)}</td>
-                      <td>{fmtTime(effectiveTime(lvl.timeSec, mainBuildingLevel))}</td>
-                      <td>{stat.value}</td>
-                    </tr>
-                  );
-                },
-              ) ?? (
+              {(
+                building as unknown as { allLevelStats?: BuildingLevelStats[] }
+              ).allLevelStats?.map((lvl) => {
+                const stat = getStatLabel(lvl);
+                return (
+                  <tr
+                    key={lvl.level}
+                    className={
+                      lvl.level === building.level
+                        ? "building-panel__levels-table__current"
+                        : ""
+                    }
+                  >
+                    <td>{lvl.level}</td>
+                    <td>{fmt(lvl.costs.wood)}</td>
+                    <td>{fmt(lvl.costs.clay)}</td>
+                    <td>{fmt(lvl.costs.iron)}</td>
+                    <td>{fmt(lvl.costs.wheat)}</td>
+                    <td>
+                      {fmtTime(effectiveTime(lvl.timeSec, mainBuildingLevel))}
+                    </td>
+                    <td>{stat.value}</td>
+                  </tr>
+                );
+              }) ?? (
                 <tr>
-                  <td colSpan={7} style={{ textAlign: "center", color: "var(--text-muted)" }}>
+                  <td
+                    colSpan={7}
+                    style={{ textAlign: "center", color: "var(--text-muted)" }}
+                  >
                     Datos completos no disponibles
                   </td>
                 </tr>

--- a/games/midgard-online/sandbox-web/src/components/buildings/BuildingPanel.tsx
+++ b/games/midgard-online/sandbox-web/src/components/buildings/BuildingPanel.tsx
@@ -152,7 +152,10 @@ export function BuildingPanel({
               Nivel {targetLevel}
             </span>
             <span className="building-panel__stat-value building-panel__stat-value--next">
-              {currentStat.label}
+              {/* W-012: show the actual next-level value, not a label */}
+              {building.nextLevelStats
+                ? getStatLabel(building.nextLevelStats).value
+                : "—"}
             </span>
           </div>
         </div>

--- a/games/midgard-online/sandbox-web/src/hooks/useBuildings.ts
+++ b/games/midgard-online/sandbox-web/src/hooks/useBuildings.ts
@@ -1,13 +1,130 @@
 /**
- * useBuildings — Hook for building data and upgrade actions.
- * Will integrate with React Query + backend API.
+ * useBuildings — React Query hook for building data and upgrade actions.
+ *
+ * - Fetches all buildings from GET /villages/:id/buildings
+ * - Exposes upgradeBuilding + cancelUpgrade mutations
+ * - Listens to `building:complete` WebSocket event to sync state
+ * - Derives currentUpgrade and canUpgrade helper
  */
-export function useBuildings() {
-  // TODO: implement building queries and mutations
-  return {
-    buildings: [],
-    upgrade: (_buildingType: string) => {
-      /* noop */
+
+import { useCallback, useEffect } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getBuildings,
+  upgradeBuilding,
+  cancelBuildingUpgrade,
+  type BuildingData,
+} from "@/services/buildingService";
+import { socketService } from "@/services/socketService";
+
+// ── Types ────────────────────────────────────────────────────────
+
+export interface UseBuildings {
+  buildings: BuildingData[];
+  currentUpgrade: BuildingData | null;
+  canUpgrade: (buildingType: string) => boolean;
+  isLoading: boolean;
+  error: Error | null;
+  upgrade: (buildingType: string) => Promise<void>;
+  cancel: (buildingId: string) => Promise<void>;
+  isUpgrading: boolean;
+  isCancelling: boolean;
+}
+
+// ── Hook ─────────────────────────────────────────────────────────
+
+export function useBuildings(villageId: string | null): UseBuildings {
+  const queryClient = useQueryClient();
+
+  // ── Fetch buildings ──
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["buildings", villageId],
+    queryFn: () => getBuildings(villageId!),
+    enabled: !!villageId,
+    staleTime: 10_000,
+  });
+
+  const buildings: BuildingData[] = data ?? [];
+
+  // ── Derived state ──
+  const currentUpgrade =
+    buildings.find((b) => b.upgradeFinishAt !== null) ?? null;
+
+  const canUpgrade = useCallback(
+    (buildingType: string): boolean => {
+      // Cannot upgrade if another building is already in progress
+      if (currentUpgrade) return false;
+      const building = buildings.find((b) => b.buildingType === buildingType);
+      if (!building) return false;
+      return building.level < building.maxLevel;
     },
+    [buildings, currentUpgrade],
+  );
+
+  // ── Mutations ──
+  const upgradeMutation = useMutation({
+    mutationFn: ({ type }: { type: string }) =>
+      upgradeBuilding(villageId!, type),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["buildings", villageId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["resources", villageId],
+      });
+    },
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: ({ id }: { id: string }) => cancelBuildingUpgrade(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["buildings", villageId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["resources", villageId],
+      });
+    },
+  });
+
+  // ── WebSocket: building:complete ──
+  const handleComplete = useCallback(
+    (payload: { buildingType: string; newLevel: number }) => {
+      console.log(
+        `[WS] building:complete — ${payload.buildingType} → Lv${payload.newLevel}`,
+      );
+      void queryClient.invalidateQueries({
+        queryKey: ["buildings", villageId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["resources", villageId],
+      });
+    },
+    [queryClient, villageId],
+  );
+
+  useEffect(() => {
+    if (!villageId) return;
+    const socket = socketService.getSocket();
+    socket?.on("building:complete", handleComplete);
+    return () => {
+      socket?.off("building:complete", handleComplete);
+    };
+  }, [villageId, handleComplete]);
+
+  return {
+    buildings,
+    currentUpgrade,
+    canUpgrade,
+    isLoading,
+    error: error as Error | null,
+    upgrade: async (buildingType: string) => {
+      await upgradeMutation.mutateAsync({ type: buildingType });
+    },
+    cancel: async (buildingId: string) => {
+      await cancelMutation.mutateAsync({ id: buildingId });
+    },
+    isUpgrading: upgradeMutation.isPending,
+    isCancelling: cancelMutation.isPending,
   };
 }

--- a/games/midgard-online/sandbox-web/src/services/buildingService.ts
+++ b/games/midgard-online/sandbox-web/src/services/buildingService.ts
@@ -1,0 +1,85 @@
+/**
+ * BuildingService (frontend) — API client for building endpoints.
+ *
+ * Endpoints:
+ *   GET    /villages/:id/buildings  → list buildings with stats
+ *   POST   /buildings/upgrade       → start upgrade
+ *   DELETE /buildings/upgrade/:id   → cancel upgrade
+ */
+
+import api from "./api";
+
+// ── Types ───────────────────────────────────────────────────
+
+export interface BuildingLevelStats {
+  level: number;
+  productionPerHour?: number;
+  capacityPerResource?: number;
+  capacityWheat?: number;
+  buildTimeReduction?: number;
+  population: number;
+  timeSec: number;
+  costs: { wood: number; clay: number; iron: number; wheat: number };
+}
+
+export interface BuildingData {
+  id: string;
+  buildingType: string;
+  slotIndex: number;
+  level: number;
+  upgradeFinishAt: string | null;
+  name: string;
+  maxLevel: number;
+  currentStats: BuildingLevelStats | null;
+  nextLevelCost: {
+    wood: number;
+    clay: number;
+    iron: number;
+    wheat: number;
+  } | null;
+  nextLevelTimeSec: number | null;
+}
+
+export interface UpgradeResult {
+  building: {
+    id: string;
+    buildingType: string;
+    level: number;
+    upgradeFinishAt: string | null;
+  };
+  resourcesAfter: {
+    wood: number;
+    clay: number;
+    iron: number;
+    wheat: number;
+  };
+}
+
+// ── API calls ────────────────────────────────────────────────
+
+export async function getBuildings(villageId: string): Promise<BuildingData[]> {
+  const { data } = await api.get<{ buildings: BuildingData[] }>(
+    `/villages/${villageId}/buildings`,
+  );
+  return data.buildings;
+}
+
+export async function upgradeBuilding(
+  villageId: string,
+  buildingType: string,
+): Promise<UpgradeResult> {
+  const { data } = await api.post<UpgradeResult>("/buildings/upgrade", {
+    villageId,
+    buildingType,
+  });
+  return data;
+}
+
+export async function cancelBuildingUpgrade(
+  buildingId: string,
+): Promise<UpgradeResult> {
+  const { data } = await api.delete<UpgradeResult>(
+    `/buildings/upgrade/${buildingId}`,
+  );
+  return data;
+}

--- a/games/midgard-online/sandbox-web/src/services/buildingService.ts
+++ b/games/midgard-online/sandbox-web/src/services/buildingService.ts
@@ -31,6 +31,7 @@ export interface BuildingData {
   name: string;
   maxLevel: number;
   currentStats: BuildingLevelStats | null;
+  nextLevelStats: BuildingLevelStats | null;
   nextLevelCost: {
     wood: number;
     clay: number;
@@ -38,6 +39,7 @@ export interface BuildingData {
     wheat: number;
   } | null;
   nextLevelTimeSec: number | null;
+  effectiveBuildTimeSec: number | null;
 }
 
 export interface UpgradeResult {


### PR DESCRIPTION
## MO-05 — Buildings System

Closes #11

### Cambios

#### Backend
- **`buildingService.ts`** — Lógica completa: `getUpgradeCost`, `getBuildTime` (reducción Gran Salón `baseTime × (1 − lvl × 0.03)`), `startUpgrade` (valida ownership/recursos/cola/prerequisites), `cancelUpgrade` (reembolso 100%), `completeUpgrade` (delta población, limpia timer)
- **`routes/buildings.ts`** — `POST /buildings/upgrade` (201) + `DELETE /buildings/upgrade/:id` (200); validación Zod
- **`routes/villages.ts`** — `GET /villages/:id/buildings` enriquecido con stats de config
- **`cron/buildingChecker.ts`** — `setInterval` cada `MISSION_CHECK_INTERVAL_MS` (5s), completa edificios con `upgradeFinishAt ≤ now`, emite `building:complete` por WS a sala `village:${villageId}`
- **`index.ts`** — `startBuildingChecker()` al arrancar el servidor

#### Frontend
- **`services/buildingService.ts`** — `getBuildings`, `upgradeBuilding`, `cancelBuildingUpgrade` + tipos exportados
- **`hooks/useBuildings.ts`** — React Query fetch + mutaciones upgrade/cancel + listener WS `building:complete`; deriva `currentUpgrade` y `canUpgrade(type)`
- **`components/buildings/BuildingCard.tsx/.css`** — Countdown, barra de progreso, colores de coste, botones upgrade/cancel
- **`components/buildings/BuildingPanel.tsx/.css`** — Comparativa stats, tabla costes, badge reducción Gran Salón, acordeón niveles

### Verificación
- `tsc --noEmit` backend → ✅ 0 errores
- `tsc --noEmit` frontend → ✅ 0 errores

---

⚠️ **No merge sin aprobación de @qa**